### PR TITLE
add error detail to description

### DIFF
--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -86,7 +86,7 @@ class InvalidGrant extends OIDCProviderError {
     super(400, 'invalid_grant');
     Error.captureStackTrace(this, this.constructor);
     Object.assign(this, {
-      error_description: 'grant request is invalid',
+      error_description: 'grant request is invalid' + " " + detail,
       error_detail: detail,
     });
   }


### PR DESCRIPTION
In the OAuth refresh token flow, the user currently only sees the error `invalid_grant` and error description which was `grant request is invalid` for a bad request. The error description doesn't provide additional value so I'm also adding the detailed error to the response (e.g. `error_description: grant request is invalid refresh token not found` instead of just `error_description: grant request is invalid`)